### PR TITLE
Fix RK3399-ROC-PC-PLUS ir-remote

### DIFF
--- a/projects/Rockchip/patches/linux/default/linux-3000-rk3399-roc-pc-plus.patch
+++ b/projects/Rockchip/patches/linux/default/linux-3000-rk3399-roc-pc-plus.patch
@@ -135,9 +135,10 @@ index 000000000000..174e0656e260
 +			default-state = "on";
 +		};
 +	};
-+	ir-receivet {
++	ir-receiver {
 +		compatible = "gpio-ir-receiver";
 +		gpios = <&gpio0 RK_PA6 GPIO_ACTIVE_LOW>;
++               linux,rc-map-name = "rc-khadas";
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&ir_int>;
 +	};


### PR DESCRIPTION
Fix ir-remote for RK3399-ROC-PC-PLUS.
Protocol - NEC
User Code - 0x00FF